### PR TITLE
ASDPLNG-169: Get working with asd-pup-control repo under RHEL8

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,15 +8,15 @@
 
 * [`profile_webserver_old`](#profile_webserver_old): Configure typical webserver
 * [`profile_webserver_old::firewall`](#profile_webserver_oldfirewall): Configure firewall for webserver
-* [`profile_webserver_old::identity`](#profile_webserver_oldidentity): Install and configure extra packages needed by NCSA Identity website
-* [`profile_webserver_old::mongodb`](#profile_webserver_oldmongodb): Install and congifure mongodb
-* [`profile_webserver_old::oidc`](#profile_webserver_oldoidc): Install and configure OpenID Connect module for httpd
+* [`profile_webserver_old::identity`](#profile_webserver_oldidentity): Optional install and configure extra packages needed by NCSA Identity website
+* [`profile_webserver_old::mongodb`](#profile_webserver_oldmongodb): Optional install and congifure mongodb
+* [`profile_webserver_old::oidc`](#profile_webserver_oldoidc): Optional install and configure OpenID Connect module for httpd
 * [`profile_webserver_old::packages`](#profile_webserver_oldpackages): Configure packages and httpd service
 * [`profile_webserver_old::php`](#profile_webserver_oldphp): Install and configure PHP
 * [`profile_webserver_old::php::php5`](#profile_webserver_oldphpphp5): Install php 5.x
 * [`profile_webserver_old::php::php56`](#profile_webserver_oldphpphp56): Install php 5.6
 * [`profile_webserver_old::php::php7`](#profile_webserver_oldphpphp7): Install php 7.x
-* [`profile_webserver_old::shibboleth`](#profile_webserver_oldshibboleth): Install and configure shibbolth
+* [`profile_webserver_old::shibboleth`](#profile_webserver_oldshibboleth): Optional install and configure shibbolth
 
 ## Classes
 
@@ -79,7 +79,7 @@ List of NCSA networks used to limit access from
 
 ### <a name="profile_webserver_oldidentity"></a>`profile_webserver_old::identity`
 
-Install and configure extra packages needed by NCSA Identity website
+Optional install and configure extra packages needed by NCSA Identity website
 
 #### Examples
 
@@ -103,7 +103,7 @@ List of extra packages needed for identity website
 
 ### <a name="profile_webserver_oldmongodb"></a>`profile_webserver_old::mongodb`
 
-Install and congifure mongodb
+Optional install and congifure mongodb
 
 #### Examples
 
@@ -134,7 +134,7 @@ List of packages to install for mongodb
 
 ### <a name="profile_webserver_oldoidc"></a>`profile_webserver_old::oidc`
 
-Install and configure OpenID Connect module for httpd
+Optional install and configure OpenID Connect module for httpd
 
 #### Examples
 
@@ -318,7 +318,7 @@ List of packages to install for php
 
 ### <a name="profile_webserver_oldshibboleth"></a>`profile_webserver_old::shibboleth`
 
-Install and configure shibbolth
+Optional install and configure shibbolth
 
 #### Examples
 

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -6,13 +6,13 @@ profile_webserver_old::identity::packages:
   - "gpgme-devel"
 
 profile_webserver_old::packages::absent:
+  - "mod_evasive"
   - "mod-pagespeed-stable"
   - "mod_security"
 profile_webserver_old::packages::installed:
   - "at"
   - "httpd"
   - "mod_auth_gssapi"
-  - "mod_evasive"
   - "mod_ldap"
   - "mod_ssl"
 

--- a/manifests/identity.pp
+++ b/manifests/identity.pp
@@ -1,4 +1,4 @@
-# @summary Install and configure extra packages needed by NCSA Identity website
+# @summary Optional install and configure extra packages needed by NCSA Identity website
 #
 # @param packages
 #   List of extra packages needed for identity website

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,9 +4,9 @@
 #   include profile_webserver_old
 class profile_webserver_old {
 
-  include webserver::firewall
-  include webserver::packages
-  include webserver::php
+  include profile_webserver_old::firewall
+  include profile_webserver_old::packages
+  include profile_webserver_old::php
   #include common::oom
 
   # config settings

--- a/manifests/mongodb.pp
+++ b/manifests/mongodb.pp
@@ -1,4 +1,4 @@
-# @summary Install and congifure mongodb
+# @summary Optional install and congifure mongodb
 #
 # @param directories
 #   List of directories needed for mongodb

--- a/manifests/oidc.pp
+++ b/manifests/oidc.pp
@@ -1,4 +1,4 @@
-# @summary Install and configure OpenID Connect module for httpd
+# @summary Optional install and configure OpenID Connect module for httpd
 #
 # @param packags
 #   List of package resources for OpenID Connect

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -17,16 +17,17 @@ class profile_webserver_old::packages (
   ensure_packages( $installed, {'ensure' => 'present', 'notify' => 'Service[httpd]'} )
 
   file { '/etc/httpd/conf.d/mod_evasive.conf':
-    ensure => 'file',
-    source => [
-      "puppet:///modules/${module_name}/etc/httpd/conf.d/mod_evasive.conf.${::hostname}",
-      "puppet:///modules/${module_name}/etc/httpd/conf.d/mod_evasive.conf.${::domain}",
-      "puppet:///modules/${module_name}/etc/httpd/conf.d/mod_evasive.conf.default",
-    ],
-    mode   => '0644',
-    owner  => 'root',
-    group  => 'root',
-    notify => Service['httpd'],
+    ensure => 'absent',
+#    ensure => 'file',
+#    source => [
+#      "puppet:///modules/${module_name}/etc/httpd/conf.d/mod_evasive.conf.${::hostname}",
+#      "puppet:///modules/${module_name}/etc/httpd/conf.d/mod_evasive.conf.${::domain}",
+#      "puppet:///modules/${module_name}/etc/httpd/conf.d/mod_evasive.conf.default",
+#    ],
+#    mode   => '0644',
+#    owner  => 'root',
+#    group  => 'root',
+#    notify => Service['httpd'],
   }
 
   service { 'httpd':

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -26,9 +26,9 @@ class profile_webserver_old::php (
 ) {
 
   case $version {
-    '7':      { include webserver::php::php7 }
-    '5.6':    { include webserver::php::php56 }
-    default:  { include webserver::php::php5 }
+    '7':      { include profile_webserver_old::php::php7 }
+    '5.6':    { include profile_webserver_old::php::php56 }
+    default:  { include profile_webserver_old::php::php5 }
   }
 
   file { $ini_file:

--- a/manifests/shibboleth.pp
+++ b/manifests/shibboleth.pp
@@ -1,4 +1,4 @@
-# @summary Install and configure shibbolth
+# @summary Optional install and configure shibbolth
 #
 # @param packages
 #   List of packages to install for shibboleth


### PR DESCRIPTION
Fix references to old class name
Remove mod_evasive entirely

See https://jira.ncsa.illinois.edu/browse/ASDPLNG-169

This profile is porting legacy code from `its-foreman` puppet. It is only about porting existing functionality, not improving it. The entire profile should be reviewed, not just the few changes in this PR.

This is being tested on: `web6`