### PR TITLE
ASDPLNG-169: Fixing more issues

### DIFF
--- a/manifests/oidc.pp
+++ b/manifests/oidc.pp
@@ -13,6 +13,6 @@ class profile_webserver_old::oidc (
     'notify' => 'Service[httpd]',
   }
 
-  ensure_resources('package', $packages, $ensure_packages_defaults )
+  ensure_packages($packages, $ensure_packages_defaults )
 
 }

--- a/manifests/php/php56.pp
+++ b/manifests/php/php56.pp
@@ -32,13 +32,6 @@ class profile_webserver_old::php::php56 (
       'Exec[uninstall_other_php_pkgs]',
     ],
   }
-  ensure_resources('package', $packages, $ensure_packages_defaults )
-  #ensure_packages( $packages, {'ensure' => 'installed', 'notify' => 'Service[httpd]'} )
-
-  ## ABOVE SHOULD REALLY ALSO REQUIRE FOLLOWING BUT NOT SURE HOW TO DO THAT
-  #  require => [
-  #    Package['webtatic-release'],
-  #    Exec['uninstall_other_php_pkgs'],
-  #  ],
+  ensure_packages($packages, $ensure_packages_defaults )
 
 }

--- a/manifests/shibboleth.pp
+++ b/manifests/shibboleth.pp
@@ -24,7 +24,7 @@ class profile_webserver_old::shibboleth (
     'ensure'  => 'installed',
     'require' => 'Yumrepo[shibboleth]',
   }
-  ensure_resources('package', $packages, $ensure_packages_defaults )
+  ensure_packages($packages, $ensure_packages_defaults )
 
   # CONFIGS
   file { '/etc/shibboleth':


### PR DESCRIPTION
Fix ensure_packages where using defaults

This change is now being tested on several hosts:
```
avl-test
campuscluster-test
edream-test
internal-dev
internal-test
lci
ncsatest
web6
```

This is a small change, but just trying to get this and changes for this in `asd-pup-control` merged to production.