### PR TITLE
SVCPLAN-2822: Update shibboleth

### DIFF
--- a/files/etc/shibboleth/uiuc-shibboleth2.xml
+++ b/files/etc/shibboleth/uiuc-shibboleth2.xml
@@ -16,15 +16,14 @@
 		     Lifetime is the max length of a session in seconds.
 		     Timeout is the inactivity time-out in seconds.
 		-->
-		<Sessions lifetime="28800" timeout="3600" relayState="ss:mem"
+		<Sessions lifetime="28800" timeout="3600" relayState="ss:mem" redirectLimit="exact"
 			checkAddress="false" handlerSSL="true" cookieProps="https">
 			    <!--
 				 Below setting will use Urbana campus
 				 IDP only.
 			    -->
-			    <SSO entityID="urn:mace:incommon:uiuc.edu"
-			    discoveryProtocol="SAMLDS" discoveryURL="">
-			    SAML2 SAML1
+                            <SSO entityID="urn:mace:incommon:uiuc.edu">
+                            SAML2 SAML1
 			</SSO>
 			<Logout>SAML2 Local</Logout>
 			<Handler type="MetadataGenerator" Location="/Metadata" signing="false"/>

--- a/manifests/shibboleth.pp
+++ b/manifests/shibboleth.pp
@@ -56,7 +56,7 @@ class profile_webserver_old::shibboleth (
   exec { 'shib_keygen':
     path    => ['/usr/bin', '/usr/sbin'],
     cwd     => '/etc/shibboleth',
-    command => "/etc/shibboleth/keygen.sh –h ${::fqdn} –e https://${::fqdn}/shibboleth -f -y 10",
+    command => "/etc/shibboleth/keygen.sh –h ${::fqdn} –e https://${::fqdn}/shibboleth -f -y 10  && chown shibd /etc/shibboleth/sp-key.pem",
     creates => '/etc/shibboleth/sp-key.pem',
     notify  => Service['shibd'],
     require => [


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SVCPLAN-2822

Turns out that the puppet module only puts a UIUC sample `/etc/shibboleth/uiuc-shibboleth2.xml` file in place. It is up to the admin to manually copy and update that file to `/etc/shibboleth/shibboleth2.xml`. So this change is primarily just updating the template file, rather than the `shibboleth2.xml` file that is actually used.

Also fixed an issue where the generated private shibboleth key was not getting permissions to let the `shibd` service & user to be able to read it.

This is being tested on `campuscluster-test`.